### PR TITLE
Adds `flow-node` bin

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,20 @@ fs.writeFileSync('output.js', output);
 **Browserify:** [`unflowify`](https://github.com/leebyron/unflowify)
 
 
+## Use `flow-node`
+
+Wherever you use `node` you can substitute `flow-node` and have a super fast
+flow-types aware evaluator or REPL.
+
+```
+$ flow-node
+> var x: number = 42
+undefined
+> x
+42
+```
+
+
 ## Use the require hook
 
 Using the require hook allows you to automatically compile files on the fly when

--- a/flow-node
+++ b/flow-node
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+
+var fs = require('fs');
+var Module = require('module');
+var path = require('path');
+var repl = require('repl');
+var util = require('util');
+var vm = require('vm');
+
+var removeTypes = require('./index');
+require('./register');
+
+var usage = 'Usage: flow-node [options] [ script.js ] [arguments] \n' +
+
+'\nOptions:\n' +
+'  -h, --help            Show this message\n' +
+'  -e, --eval script     Evaluate script\n' +
+'  -p, --print script    Evaluate script and print result\n' +
+'  -c, --check           Syntax check script without executing\n';
+
+// Collect arguments
+var evalScript;
+var printScript;
+var checkSource;
+var source;
+var i = 2;
+while (i < process.argv.length) {
+  var arg = process.argv[i++];
+  if (arg === '-h' || arg === '--help') {
+    process.stdout.write(usage);
+    process.exit(0);
+  } else if (arg === '-e' || arg === '--eval') {
+    evalScript = process.argv[i++];
+    if (!evalScript) {
+      process.stderr.write('flow-node: ' + arg + ' requires an argument');
+      return process.exit(1);
+    }
+  } else if (arg === '-p' || arg === '--print') {
+    printScript = process.argv[i++];
+    if (!printScript) {
+      process.stderr.write('flow-node: ' + arg + ' requires an argument');
+      return process.exit(1);
+    }
+  } else if (arg === '-c' || arg === '--check') {
+    checkSource = true;
+  } else if (arg[0] !== '-') {
+    source = arg;
+    break;
+  }
+}
+
+// Evaluate and possibly also print a script.
+if (evalScript || printScript) {
+  global.__filename = '[eval]';
+  global.__dirname = process.cwd();
+  var evalModule = new Module(global.__filename);
+  evalModule.filename = global.__filename;
+  evalModule.paths = Module._nodeModulePaths(global.__dirname);
+  global.exports = evalModule.exports;
+  global.module = evalModule;
+  global.require = evalModule.require.bind(evalModule);
+  var result = eval(evalScript || printScript, global.__filename);
+  if (printScript) {
+    process.stdout.write((typeof result === 'string' ? result : util.inspect(result)) + '\n');
+  }
+
+// Or check the source for syntax errors but do not run it.
+} else if (source && checkSource) {
+  var code = fs.readFileSync(source, 'utf8');
+  try {
+    removeTypes(code);
+  } catch (error) {
+    var lines = code.split(/\r\n?|\n|\u2028|\u2029/);
+    process.stdout.write(source + ':' + error.loc.line + '\n');
+    process.stdout.write(lines[error.loc.line - 1] + '\n');
+    process.stdout.write(Array(error.loc.column + 1).join(' ') + '^\n');
+    process.stdout.write(error.stack + '\n');
+    return process.exit(1);
+  }
+
+// Or run the script.
+} else if (source) {
+  var absoluteSource = path.resolve(process.cwd(), source);
+  process.argv = [ 'node' ].concat(
+    process.argv.slice(2, i - 1),
+    absoluteSource,
+    process.argv.slice(i)
+  );
+  process.execArgv.unshift(__filename);
+  Module.runMain();
+
+// Or begin a REPL.
+} else {
+  repl.start({
+    prompt: '> ',
+    input: process.stdin,
+    output: process.stdout,
+    useGlobal: true,
+    eval: function (code, context, filename, callback) {
+      var error;
+      var result;
+      try {
+        result = eval(code, filename);
+      } catch (err) {
+        error = err;
+      }
+      callback(error, result);
+    }
+  });
+}
+
+function eval(code, filename) {
+  return vm.runInThisContext(
+    removeTypes(code, { checkPragma: false }),
+    { filename: filename }
+  );
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,10 @@
   "author": "Lee Byron <lee@leebyron.com> (http://leebyron.com/)",
   "license": "BSD-3-Clause",
   "main": "index.js",
-  "bin": "flow-remove-types",
+  "bin": {
+    "flow-remove-types": "./flow-remove-types",
+    "flow-node": "./flow-node"
+  },
   "homepage": "https://github.com/leebyron/flow-remove-types",
   "bugs": {
     "url": "https://github.com/leebyron/flow-remove-types/issues"
@@ -15,7 +18,7 @@
     "url": "http://github.com/leebyron/flow-remove-types.git"
   },
   "scripts": {
-    "test": "DIFF=$(./flow-remove-types test/source.js | diff test/expected.js -); if [ -n \"$DIFF\" ]; then echo \"$DIFF\"; exit 1; fi; RES=$(node -e 'require(\"./register\");require(\"./test/test-node-module.js\")'); if [[ \"$RES\" != 42 ]]; then echo 'Node register hook failed'; exit 1; fi;",
+    "test": "DIFF=$(./flow-remove-types test/source.js | diff test/expected.js -); if [ -n \"$DIFF\" ]; then echo \"$DIFF\"; exit 1; fi; RES=$(node -e 'require(\"./register\");require(\"./test/test-node-module.js\")'); if [ \"$RES\" != 42 ]; then echo 'Node register hook failed'; exit 1; fi; FLOW_NODE=$(./flow-node ./test/test-node-module.js); if [ \"$FLOW_NODE\" != 42 ]; then echo 'flow-node failed'; exit 1; fi;",
     "test-update": "./flow-remove-types test/source.js > test/expected.js"
   },
   "keywords": [


### PR DESCRIPTION
The `flow-node` bin is a drop-in replacement for `node` but accepts files with flow type definitions.

Wherever you use `node` you can substitute `flow-node` and have a super fast
flow-types aware evaluator or REPL.

```
$ flow-node
> var x: number = 42
undefined
> x
42
```