### PR TITLE
Print newline after version number

### DIFF
--- a/flow-node
+++ b/flow-node
@@ -31,7 +31,7 @@ while (i < process.argv.length) {
     process.stdout.write(usage);
     process.exit(0);
   } else if (arg === '-v' || arg === '--version') {
-    process.stdout.write('v' + require('./package').version);
+    process.stdout.write('v' + require('./package').version + '\n');
     process.exit(0);
   } else if (arg === '-e' || arg === '--eval') {
     evalScript = process.argv[i++];


### PR DESCRIPTION
When running `flow-node --version`, we should print a newline after the version number (like `node` does).