### PR TITLE
Do not publish tests

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,4 @@
+.DS_Store
+npm-debug.log
+node_modules
+test


### PR DESCRIPTION
When installing the module in a project I noticed that the `test/source.js` file causes flow errors because of nonexistent imported modules.

This PR adds a `.npmignore` based on the `.gitignore` to stop npm from publishing the `test/` directory.